### PR TITLE
fixed: concurrent beginSheet / endSheet is not correctly handled

### DIFF
--- a/AppKit/CPWindow/CPWindow.j
+++ b/AppKit/CPWindow/CPWindow.j
@@ -2857,6 +2857,13 @@ CPTexturedBackgroundWindowMask
     if (_sheetContext["isClosing"])
         return;
 
+    if (_sheetContext["isOpening"])
+    {
+        // Allow sheet to be closed while opening, it will close when current animation is complete
+        _sheetContext["shouldClose"] = YES;
+        return;
+    }
+
     _sheetContext["isAttached"] = NO;
     _sheetContext["isClosing"] = YES;
     _sheetContext["opened"] = NO;
@@ -3034,9 +3041,14 @@ CPTexturedBackgroundWindowMask
 
         // we wanted to close the sheet while it animated in, do that now
         if (_sheetContext["shouldClose"] === YES)
+        {
+            _sheetContext["shouldClose"] = NO;
             [self _detachSheetWindow];
-        else
+        } 
+        else 
+        {
             [sheet makeKeyWindow];
+        }
     }
     else
     {


### PR DESCRIPTION
In the following scenario:
1. Open a sheet with  `[CPApp beginSheet:modalForWindow:modalDelegate:didEndSelector:@selector(didEndSheet:returnCode:contextInfo:)contextInfo:nil]`
2. Before the beginSheet animation is complete (let say after 100 ms), call `[CPApp endSheet:returnCode:]`
3. In the didEndSelector, call `[mysheet orderOut:self];` to hide the sheet

This creates a concurrency bug that was not correctly handled. The sheet _DOMElement would be removed while the animation is in progress causing a DOM exception under Safari and Firefox (cannot reproduce it on Chrome).

This is due to the fact the _detachSheetWindow is called by orderOut: and does not check if an opening animation is in progress.

This PR fixes that.
